### PR TITLE
Loosen pyexiv2 version pin to support ARM64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 from setuptools import find_packages, setup
 
 
-VERSION = '1.3.12'
+VERSION = '1.3.13'
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
     README = readme.read()
@@ -24,7 +24,7 @@ setup(
     author='Rehive',
     author_email='info@rehive.com',
     license='MIT',
-    install_requires=["Django>=3.0", "pyexiv2==2.7.1", "django-filter>=21.0"],
+    install_requires=["Django>=3.0", "pyexiv2>=2.7.1", "django-filter>=21.0"],
     python_requires='>=3.6',
     classifiers=[
         'Framework :: Django',


### PR DESCRIPTION
## Summary
- Change `pyexiv2==2.7.1` to `pyexiv2>=2.7.1` to allow ARM64-compatible versions
- `pyexiv2==2.7.1` only has x86_64 wheels on PyPI, making it impossible to install on ARM64/aarch64
- The API usage in `fields.py` (`ImageData`, `clear_exif`, `get_bytes`) is compatible with newer versions (2.15.x)
- Bump version to 1.3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)