### PR TITLE
Fix pyexiv2 pin for ARM64 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author='Rehive',
     author_email='info@rehive.com',
     license='MIT',
-    install_requires=["Django>=3.0", "pyexiv2>=2.15.4", "django-filter>=21.0"],
+    install_requires=["Django>=3.0", "pyexiv2==2.15.5", "django-filter>=21.0"],
     python_requires='>=3.6',
     classifiers=[
         'Framework :: Django',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from codecs import open
 from setuptools import find_packages, setup
 
 
-VERSION = '1.3.13'
+VERSION = '1.3.15'
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
     README = readme.read()
@@ -24,7 +24,7 @@ setup(
     author='Rehive',
     author_email='info@rehive.com',
     license='MIT',
-    install_requires=["Django>=3.0", "pyexiv2>=2.7.1", "django-filter>=21.0"],
+    install_requires=["Django>=3.0", "pyexiv2>=2.15.4", "django-filter>=21.0"],
     python_requires='>=3.6',
     classifiers=[
         'Framework :: Django',


### PR DESCRIPTION
## Summary
- `pyexiv2>=2.7.1` has no `manylinux2014_aarch64` wheel — Docker builds fail on ARM64
- Pinned to `pyexiv2==2.15.5` (latest, has both x86_64 and aarch64 wheels)
- Bumped version to 1.3.15

## Context
The 1.3.14 release was intended to add ARM64 support, but the pyexiv2 pin still referenced a version without ARM64 wheels, causing `pip install` to fail during Docker builds on ARM64 machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)